### PR TITLE
Support automatic forward-paging of entity collections

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+max_line_length = 120
+tab_width = 4
+
+[{*.ctp,*.engine,*.hphp,*.inc,*.install,*.module,*.php,*.php4,*.php5,*.phtml,*.profile,*.test,*.theme}]
+max_line_length = 80

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ vendor/
 build/
 
 .idea/
+
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "guzzlehttp/psr7": "^1.6",
         "php-http/client-implementation": "^1.0",
         "psr/http-client": "^1.0",
-        "psr/http-message": "^1.0"
+        "psr/http-message": "^1.0",
+        "symfony/serializer": "^5.2"
     },
     "require-dev": {
         "php-http/mock-client": "^1.3",

--- a/src/Entity/Collection/CollectionRelLinkTrait.php
+++ b/src/Entity/Collection/CollectionRelLinkTrait.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Hussainweb\DrupalApi\Entity\Collection;
+
+use GuzzleHttp\Psr7\Uri;
+
+/**
+ * Trait for relationship links in collections.
+ *
+ * @see \Hussainweb\DrupalApi\Entity\Collection\EntityCollectionInterface
+ */
+trait CollectionRelLinkTrait
+{
+
+  /**
+   * @var \stdClass
+   */
+    protected $rawData;
+
+    public function getSelfLink()
+    {
+        return $this->getRelLink('self');
+    }
+
+    public function getFirstLink()
+    {
+        return $this->getRelLink('first');
+    }
+
+    public function getPreviousLink()
+    {
+        return $this->getRelLink('prev');
+    }
+
+    public function getLastLink()
+    {
+        return $this->getRelLink('last');
+    }
+
+    public function getNextLink()
+    {
+        return $this->getRelLink('next');
+    }
+
+    /**
+     * Get the related link.
+     *
+     * @param string $link_name
+     *   The name of the related link to retrieve.
+     *
+     * @return bool|\Psr\Http\Message\UriInterface
+     *   The related URL or FALSE if not present.
+     */
+    protected function getRelLink(string $link_name)
+    {
+        if (!isset($this->rawData->$link_name)) {
+            return false;
+        }
+
+        $uri = new Uri($this->rawData->$link_name);
+        $uri = $uri->withPath($uri->getPath() . '.json');
+        return $uri;
+    }
+
+}

--- a/src/Entity/Collection/CollectionRelLinkTrait.php
+++ b/src/Entity/Collection/CollectionRelLinkTrait.php
@@ -61,5 +61,4 @@ trait CollectionRelLinkTrait
         $uri = $uri->withPath($uri->getPath() . '.json');
         return $uri;
     }
-
 }

--- a/src/Entity/Collection/EntityCollection.php
+++ b/src/Entity/Collection/EntityCollection.php
@@ -8,6 +8,7 @@ use Symfony\Component\Serializer\Encoder\JsonEncoder;
 
 abstract class EntityCollection implements \Iterator, \Countable
 {
+    use CollectionRelLinkTrait;
 
     private $iteratorPosition = 0;
 
@@ -33,51 +34,6 @@ abstract class EntityCollection implements \Iterator, \Countable
     public static function fromResponse(ResponseInterface $response)
     {
         return new static((new JsonDecode())->decode((string) $response->getBody(), JsonEncoder::FORMAT));
-    }
-
-    public function getSelfLink()
-    {
-        return $this->getRelLink('self');
-    }
-
-    public function getFirstLink()
-    {
-        return $this->getRelLink('first');
-    }
-
-    public function getPreviousLink()
-    {
-        return $this->getRelLink('prev');
-    }
-
-    public function getNextLink()
-    {
-        return $this->getRelLink('next');
-    }
-
-    public function getLastLink()
-    {
-        return $this->getRelLink('last');
-    }
-
-    /**
-     * Get the related link.
-     *
-     * @param string $link_name
-     *   The name of the related link to retrieve.
-     *
-     * @return bool|\Psr\Http\Message\UriInterface
-     *   The related URL or FALSE if not present.
-     */
-    protected function getRelLink($link_name)
-    {
-        if (!isset($this->rawData->$link_name)) {
-            return false;
-        }
-
-        $uri = new Uri($this->rawData->$link_name);
-        $uri = $uri->withPath($uri->getPath() . '.json');
-        return $uri;
     }
 
     /**

--- a/src/Entity/Collection/EntityCollection.php
+++ b/src/Entity/Collection/EntityCollection.php
@@ -2,8 +2,9 @@
 
 namespace Hussainweb\DrupalApi\Entity\Collection;
 
-use GuzzleHttp\Psr7\Uri;
 use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\Encoder\JsonDecode;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
 
 abstract class EntityCollection implements \Iterator, \Countable
 {
@@ -31,7 +32,7 @@ abstract class EntityCollection implements \Iterator, \Countable
      */
     public static function fromResponse(ResponseInterface $response)
     {
-        return new static(json_decode((string) $response->getBody()));
+        return new static((new JsonDecode())->decode((string) $response->getBody(), JsonEncoder::FORMAT));
     }
 
     public function getSelfLink()

--- a/src/Entity/Collection/EntityCollection.php
+++ b/src/Entity/Collection/EntityCollection.php
@@ -2,6 +2,7 @@
 
 namespace Hussainweb\DrupalApi\Entity\Collection;
 
+use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\Encoder\JsonDecode;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
@@ -34,6 +35,21 @@ abstract class EntityCollection implements EntityCollectionInterface, \Countable
     public static function fromResponse(ResponseInterface $response)
     {
         return new static((new JsonDecode())->decode((string) $response->getBody(), JsonEncoder::FORMAT));
+    }
+
+    /**
+     * Construct a paging entity collection from this collection.
+     *
+     * @param \Psr\Http\Client\ClientInterface $client
+     *   The HTTP client used to fetch subsequent pages.
+     *
+     * @see \Hussainweb\DrupalApi\Client::getEntity
+     *
+     * @return \Hussainweb\DrupalApi\Entity\Collection\PagingEntityCollection
+     */
+    public function toPagingEntityCollection(ClientInterface $client): PagingEntityCollection
+    {
+        return new PagingEntityCollection($this->rawData, $client, $this->getListItemClass());
     }
 
     /**

--- a/src/Entity/Collection/EntityCollection.php
+++ b/src/Entity/Collection/EntityCollection.php
@@ -6,7 +6,7 @@ use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\Encoder\JsonDecode;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 
-abstract class EntityCollection implements \Iterator, \Countable
+abstract class EntityCollection implements EntityCollectionInterface, \Countable
 {
     use CollectionRelLinkTrait;
 
@@ -72,7 +72,7 @@ abstract class EntityCollection implements \Iterator, \Countable
     /**
      * {@inheritdoc}
      */
-    public function valid()
+    public function valid(): bool
     {
         return isset($this->rawData->list[$this->iteratorPosition]);
     }

--- a/src/Entity/Collection/EntityCollectionInterface.php
+++ b/src/Entity/Collection/EntityCollectionInterface.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Hussainweb\DrupalApi\Entity\Collection;
+
+/**
+ * Interface representing a collection of entities loaded from drupal.org.
+ */
+interface EntityCollectionInterface extends \Iterator
+{
+
+    /**
+     * @return bool|\GuzzleHttp\Psr7\Uri
+     */
+    public function getSelfLink();
+
+    /**
+     * @return bool|\GuzzleHttp\Psr7\Uri
+     */
+    public function getFirstLink();
+
+    /**
+     * @return bool|\GuzzleHttp\Psr7\Uri
+     */
+    public function getPreviousLink();
+
+    /**
+     * @return bool|\GuzzleHttp\Psr7\Uri
+     */
+    public function getNextLink();
+
+    /**
+     * @return bool|\GuzzleHttp\Psr7\Uri
+     */
+    public function getLastLink();
+
+    /**
+     * {@inheritdoc}
+     */
+    public function current();
+
+    /**
+     * {@inheritdoc}
+     */
+    public function next();
+
+    /**
+     * {@inheritdoc}
+     */
+    public function key();
+
+    /**
+     * {@inheritdoc}
+     */
+    public function valid(): bool;
+
+    /**
+     * {@inheritdoc}
+     *
+     * If a collection does not support rewinding, implement this method with an
+     * empty body.
+     */
+    public function rewind();
+}

--- a/src/Entity/Collection/PagingEntityCollection.php
+++ b/src/Entity/Collection/PagingEntityCollection.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hussainweb\DrupalApi\Entity\Collection;
+
+use Hussainweb\DrupalApi\Request\Request;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\Encoder\JsonDecode;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+
+/**
+ * A collection of entities loaded from drupal.org that supports automatic
+ * forward-paging.
+ */
+class PagingEntityCollection implements EntityCollectionInterface
+{
+    use CollectionRelLinkTrait;
+
+    private $iteratorPosition = 0;
+
+    /**
+     * @var \stdClass
+     */
+    protected $rawData;
+
+    /**
+     * @var \Psr\Http\Client\ClientInterface
+     */
+    private $client;
+
+    /**
+     * @var string
+     */
+    private $listItemClass;
+
+    /**
+     * PagingEntityCollection constructor.
+     *
+     * @param \stdClass $data
+     *   The data with the first page response.
+     * @param \Psr\Http\Client\ClientInterface $client
+     *   The HTTP client used to fetch subsequent pages.
+     * @param string $listItemClass
+     *   The list item class FQCN to deserialize entities into.
+     */
+    final public function __construct(
+        \stdClass $data,
+        ClientInterface $client,
+        string $listItemClass
+    ) {
+        $this->rawData = $data;
+        $this->client = $client;
+        $this->listItemClass = $listItemClass;
+    }
+
+    /**
+     * Construct the object from a HTTP Response.
+     *
+     * @param \Psr\Http\Message\ResponseInterface $response
+     *   Response object to parse.
+     * @param \Psr\Http\Client\ClientInterface $client
+     *   The HTTP client used to fetch subsequent pages.
+     * @param string $listItemClass
+     *   The list item class FQCN to deserialize entities into.
+     *
+     * @return static
+     *   The EntityCollection object for the response.
+     */
+    public static function fromResponse(
+        ResponseInterface $response,
+        ClientInterface $client,
+        string $listItemClass
+    ): self {
+        return new static(
+            (new JsonDecode())->decode(
+                (string) $response->getBody(),
+                JsonEncoder::FORMAT
+            ),
+            $client,
+            $listItemClass
+        );
+    }
+
+    public function current()
+    {
+        return new $this->listItemClass(
+            $this->rawData->list[$this->iteratorPosition]
+        );
+    }
+
+    public function next()
+    {
+        ++$this->iteratorPosition;
+    }
+
+    public function key()
+    {
+        return $this->iteratorPosition;
+    }
+
+    public function valid(): bool
+    {
+        $valid = isset($this->rawData->list[$this->iteratorPosition]);
+        if (!$valid && $this->getNextLink()) {
+            $request = new Request((string) $this->getNextLink());
+            $response = $this->client->sendRequest($request);
+            $this->rawData = (new JsonDecode())->decode(
+                (string) $response->getBody(),
+                JsonEncoder::FORMAT
+            );
+            $this->iteratorPosition = 0;
+            $valid = true;
+        }
+
+        return $valid;
+    }
+
+    public function rewind()
+    {
+        // We do not allow rewinding as that could force us to go back and reload a
+        // previously loaded page.
+    }
+}

--- a/tests/Entity/Collection/PagingEntityCollectionTest.php
+++ b/tests/Entity/Collection/PagingEntityCollectionTest.php
@@ -5,7 +5,6 @@ namespace Hussainweb\DrupalApi\Tests\Entity\Collection;
 use GuzzleHttp\Psr7\Response;
 use Hussainweb\DrupalApi\Entity\Collection\PagingEntityCollection;
 use Hussainweb\DrupalApi\Entity\Comment;
-use Hussainweb\DrupalApi\Request\Collection\CollectionRequest;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Client\ClientInterface;
 

--- a/tests/Entity/Collection/PagingEntityCollectionTest.php
+++ b/tests/Entity/Collection/PagingEntityCollectionTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Hussainweb\DrupalApi\Tests\Entity\Collection;
+
+use GuzzleHttp\Psr7\Response;
+use Hussainweb\DrupalApi\Entity\Collection\PagingEntityCollection;
+use Hussainweb\DrupalApi\Entity\Comment;
+use Hussainweb\DrupalApi\Request\Collection\CollectionRequest;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
+
+class PagingEntityCollectionTest extends TestCase
+{
+
+    public function testPaging()
+    {
+        $data = json_decode(file_get_contents(__DIR__ . '/../../fixtures/comment-collection-page-0.json'));
+        $client = $this->createMock(ClientInterface::class);
+        $page1 = json_decode(file_get_contents(
+            __DIR__ . '/../../fixtures/comment-collection-page-1.json'
+        ));
+
+        // Modify the fixture so there's only two pages.
+        unset($page1->next);
+        $page1 = json_encode($page1);
+
+        $client->expects($this->once())->method('sendRequest')
+        ->willReturn(new Response(
+            200,
+            ['Content-Type' => 'application/json'],
+            $page1
+        ));
+        $collection = new PagingEntityCollection($data, $client, Comment::class);
+        $count = 0;
+
+        /** @var \Hussainweb\DrupalApi\Entity\Comment $comment */
+        foreach ($collection as $comment) {
+            $count++;
+            $this->assertIsInt($comment->getId());
+        }
+
+        $this->assertEquals(10, $count);
+    }
+}

--- a/tests/Entity/Collection/PagingEntityCollectionTest.php
+++ b/tests/Entity/Collection/PagingEntityCollectionTest.php
@@ -3,8 +3,12 @@
 namespace Hussainweb\DrupalApi\Tests\Entity\Collection;
 
 use GuzzleHttp\Psr7\Response;
+use Hussainweb\DrupalApi\Client;
+use Hussainweb\DrupalApi\Entity\Collection\CommentCollection;
 use Hussainweb\DrupalApi\Entity\Collection\PagingEntityCollection;
 use Hussainweb\DrupalApi\Entity\Comment;
+use Hussainweb\DrupalApi\Request\Collection\CommentCollectionRequest;
+use Hussainweb\DrupalApi\Request\Request;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Client\ClientInterface;
 
@@ -36,6 +40,39 @@ class PagingEntityCollectionTest extends TestCase
         foreach ($collection as $comment) {
             $count++;
             $this->assertIsInt($comment->getId());
+        }
+
+        $this->assertEquals(10, $count);
+    }
+
+    public function testFromClient()
+    {
+        $data = json_decode(file_get_contents(__DIR__ . '/../../fixtures/comment-collection-page-0.json'));
+        /** @var \Hussainweb\DrupalApi\Client|\PHPUnit\Framework\MockObject\MockObject $client */
+        $client = $this->createMock(Client::class);
+        $page1 = json_decode(file_get_contents(
+            __DIR__ . '/../../fixtures/comment-collection-page-1.json'
+        ));
+
+        // Modify the fixture so there's only two pages.
+        unset($page1->next);
+        $page1 = json_encode($page1);
+
+        $comment_collection = new CommentCollection($data);
+        $client->expects($this->once())->method('getEntity')
+            ->willReturn($comment_collection);
+
+        $request = new CommentCollectionRequest();
+        $entity_collection = $client->getEntity($request);
+
+        $http_client = $this->createMock(ClientInterface::class);
+        $http_client->expects($this->once())->method('sendRequest')
+            ->willReturn(new Response(200, ['Content-Type' => 'application/json'], $page1));
+        $paging_collection = $entity_collection->toPagingEntityCollection($http_client);
+        $count = 0;
+        foreach ($paging_collection as $comment) {
+            $count++;
+            $this->assertInstanceOf(Comment::class, $comment);
         }
 
         $this->assertEquals(10, $count);

--- a/tests/Entity/Collection/PagingEntityCollectionTest.php
+++ b/tests/Entity/Collection/PagingEntityCollectionTest.php
@@ -8,7 +8,6 @@ use Hussainweb\DrupalApi\Entity\Collection\CommentCollection;
 use Hussainweb\DrupalApi\Entity\Collection\PagingEntityCollection;
 use Hussainweb\DrupalApi\Entity\Comment;
 use Hussainweb\DrupalApi\Request\Collection\CommentCollectionRequest;
-use Hussainweb\DrupalApi\Request\Request;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Client\ClientInterface;
 

--- a/tests/fixtures/comment-collection-page-0.json
+++ b/tests/fixtures/comment-collection-page-0.json
@@ -1,0 +1,143 @@
+{
+  "self": "https://www.drupal.org/api-d7/comment?page=0&limit=5",
+  "first": "https://www.drupal.org/api-d7/comment?page=0&limit=5",
+  "last": "https://www.drupal.org/api-d7/comment?page=1720433&limit=5",
+  "next": "https://www.drupal.org/api-d7/comment?page=1&limit=5",
+  "list": [
+    {
+      "comment_body": {
+        "value": "<p>We're currently working on Access '95 integration. But Access '97 will be one of the first features when we start work on 2.0!!!</p>",
+        "format": "1"
+      },
+      "field_attribute_contribution_to": [],
+      "field_for_customer": [],
+      "field_attribute_as_volunteer": [],
+      "cid": "5076802",
+      "name": "JohnAlbin",
+      "homepage": "",
+      "subject": "",
+      "url": "https://www.drupal.org/project/vaporware/issues/1166082#comment-5076802",
+      "edit_url": "https://www.drupal.org/comment/edit/5076802",
+      "created": "876044700",
+      "node": {
+        "uri": "https://www.drupal.org/api-d7/node/1166082",
+        "id": "1166082",
+        "resource": "node"
+      },
+      "author": {
+        "uri": "https://www.drupal.org/api-d7/user/32095",
+        "id": "32095",
+        "resource": "user"
+      },
+      "feeds_item_guid": null,
+      "feeds_item_url": null,
+      "feed_nid": null
+    },
+    {
+      "comment_body": {
+        "value": "<p>PHP didn't like a reference to an undefined object under an array and crashed. Fixed it and works fine again.</p>",
+        "format": "1"
+      },
+      "field_attribute_contribution_to": [],
+      "field_for_customer": [],
+      "field_attribute_as_volunteer": [],
+      "cid": "287017",
+      "name": "",
+      "homepage": "",
+      "subject": "",
+      "url": "https://www.drupal.org/project/drupal/issues/6#comment-287017",
+      "edit_url": "https://www.drupal.org/comment/edit/287017",
+      "created": "1008599295",
+      "node": {
+        "uri": "https://www.drupal.org/api-d7/node/6",
+        "id": "6",
+        "resource": "node"
+      },
+      "feeds_item_guid": null,
+      "feeds_item_url": null,
+      "feed_nid": null
+    },
+    {
+      "comment_body": {
+        "value": "<p>Fixed.</p>",
+        "format": "1"
+      },
+      "field_attribute_contribution_to": [],
+      "field_for_customer": [],
+      "field_attribute_as_volunteer": [],
+      "cid": "287019",
+      "name": "",
+      "homepage": "",
+      "subject": "",
+      "url": "https://www.drupal.org/project/drupal/issues/7#comment-287019",
+      "edit_url": "https://www.drupal.org/comment/edit/287019",
+      "created": "1008601237",
+      "node": {
+        "uri": "https://www.drupal.org/api-d7/node/7",
+        "id": "7",
+        "resource": "node"
+      },
+      "feeds_item_guid": null,
+      "feeds_item_url": null,
+      "feed_nid": null
+    },
+    {
+      "comment_body": {
+        "value": "<p>This is a very useful function.  Maybe it should also make the post private in the blog.  In other words, maybe the post would only be visible to the author.  Or maybe these are two different options.  </p>\n<p>I could see using this as a way to save a draft post, or if I want to remind myself of some things within the context of the host site.</p>\n<p>- Joe</p>\n<p>&lt;!-- Feature creep... it's a healthy problem to have. --&gt;</p>",
+        "format": "1"
+      },
+      "field_attribute_contribution_to": [],
+      "field_for_customer": [],
+      "field_attribute_as_volunteer": [],
+      "cid": "287090",
+      "name": "j0e@www.drop.org",
+      "homepage": "",
+      "subject": "",
+      "url": "https://www.drupal.org/project/drupal/issues/9#comment-287090",
+      "edit_url": "https://www.drupal.org/comment/edit/287090",
+      "created": "1008635513",
+      "node": {
+        "uri": "https://www.drupal.org/api-d7/node/9",
+        "id": "9",
+        "resource": "node"
+      },
+      "author": {
+        "uri": "https://www.drupal.org/api-d7/user/15",
+        "id": "15",
+        "resource": "user"
+      },
+      "feeds_item_guid": null,
+      "feeds_item_url": null,
+      "feed_nid": null
+    },
+    {
+      "comment_body": {
+        "value": "<p>ax convinced me by referring to user privacy ... i've assigned this one to myself.</p>",
+        "format": "1"
+      },
+      "field_attribute_contribution_to": [],
+      "field_for_customer": [],
+      "field_attribute_as_volunteer": [],
+      "cid": "287021",
+      "name": "moshe weitzman",
+      "homepage": "",
+      "subject": "",
+      "url": "https://www.drupal.org/project/drupal/issues/8#comment-287021",
+      "edit_url": "https://www.drupal.org/comment/edit/287021",
+      "created": "1008653348",
+      "node": {
+        "uri": "https://www.drupal.org/api-d7/node/8",
+        "id": "8",
+        "resource": "node"
+      },
+      "author": {
+        "uri": "https://www.drupal.org/api-d7/user/23",
+        "id": "23",
+        "resource": "user"
+      },
+      "feeds_item_guid": null,
+      "feeds_item_url": null,
+      "feed_nid": null
+    }
+  ]
+}

--- a/tests/fixtures/comment-collection-page-1.json
+++ b/tests/fixtures/comment-collection-page-1.json
@@ -1,0 +1,144 @@
+{
+  "self": "https://www.drupal.org/api-d7/comment?page=1&limit=5",
+  "first": "https://www.drupal.org/api-d7/comment?page=0&limit=5",
+  "last": "https://www.drupal.org/api-d7/comment?page=1720439&limit=5",
+  "prev": "https://www.drupal.org/api-d7/comment?page=0&limit=5",
+  "next": "https://www.drupal.org/api-d7/comment?page=2&limit=5",
+  "list": [
+    {
+      "comment_body": {
+        "value": "<p>not a bug, i guess - just the admin not having created a forum yet.</p>",
+        "format": "1"
+      },
+      "field_attribute_contribution_to": [],
+      "field_for_customer": [],
+      "field_attribute_as_volunteer": [],
+      "cid": "287094",
+      "name": "ax",
+      "homepage": "",
+      "subject": "",
+      "url": "https://www.drupal.org/project/drupal/issues/11#comment-287094",
+      "edit_url": "https://www.drupal.org/comment/edit/287094",
+      "created": "1008677001",
+      "node": {
+        "uri": "https://www.drupal.org/api-d7/node/11",
+        "id": "11",
+        "resource": "node"
+      },
+      "author": {
+        "uri": "https://www.drupal.org/api-d7/user/8",
+        "id": "8",
+        "resource": "user"
+      },
+      "feeds_item_guid": null,
+      "feeds_item_url": null,
+      "feed_nid": null
+    },
+    {
+      "comment_body": {
+        "value": "<p>I think I fixed it.  It was a typo: $edit[\"uid\"] should have read $node-&gt;uid.</p>",
+        "format": "1"
+      },
+      "field_attribute_contribution_to": [],
+      "field_for_customer": [],
+      "field_attribute_as_volunteer": [],
+      "cid": "287097",
+      "name": "Dries",
+      "homepage": "",
+      "subject": "",
+      "url": "https://www.drupal.org/project/drupal/issues/16#comment-287097",
+      "edit_url": "https://www.drupal.org/comment/edit/287097",
+      "created": "1008709273",
+      "node": {
+        "uri": "https://www.drupal.org/api-d7/node/16",
+        "id": "16",
+        "resource": "node"
+      },
+      "author": {
+        "uri": "https://www.drupal.org/api-d7/user/1",
+        "id": "1",
+        "resource": "user"
+      },
+      "feeds_item_guid": null,
+      "feeds_item_url": null,
+      "feed_nid": null
+    },
+    {
+      "comment_body": {
+        "value": "<p>Fixed in CVS.</p>",
+        "format": "1"
+      },
+      "field_attribute_contribution_to": [],
+      "field_for_customer": [],
+      "field_attribute_as_volunteer": [],
+      "cid": "287095",
+      "name": "",
+      "homepage": "",
+      "subject": "",
+      "url": "https://www.drupal.org/project/drupal/issues/15#comment-287095",
+      "edit_url": "https://www.drupal.org/comment/edit/287095",
+      "created": "1008862665",
+      "node": {
+        "uri": "https://www.drupal.org/api-d7/node/15",
+        "id": "15",
+        "resource": "node"
+      },
+      "feeds_item_guid": null,
+      "feeds_item_url": null,
+      "feed_nid": null
+    },
+    {
+      "comment_body": {
+        "value": "<p>Marking as fixed. Ax: if this fixed it please close the bug.</p>",
+        "format": "1"
+      },
+      "field_attribute_contribution_to": [],
+      "field_for_customer": [],
+      "field_attribute_as_volunteer": [],
+      "cid": "287098",
+      "name": "",
+      "homepage": "",
+      "subject": "",
+      "url": "https://www.drupal.org/project/drupal/issues/16#comment-287098",
+      "edit_url": "https://www.drupal.org/comment/edit/287098",
+      "created": "1008862728",
+      "node": {
+        "uri": "https://www.drupal.org/api-d7/node/16",
+        "id": "16",
+        "resource": "node"
+      },
+      "feeds_item_guid": null,
+      "feeds_item_url": null,
+      "feed_nid": null
+    },
+    {
+      "comment_body": {
+        "value": "<p>this fixes the \"Submitted by anonymous\" issue - but the missing link(s) remain. i don't know if /you/ consider it a bug that the preview shows different (less) links than the actual, finished node (in the example of a blog: preview shows only \"update this blog\"; actual node - node.php?id=X - shows \"update this blog\" and \"add new comment\") - i /do/ consider it a bug, so i leave this open.</p>\n<p>note: other node types may have more, different and more \"important\" links than blogs.</p>\n<p>feel free to close this bug if you dont agree. or should this be made a separate report?</p>",
+        "format": "1"
+      },
+      "field_attribute_contribution_to": [],
+      "field_for_customer": [],
+      "field_attribute_as_volunteer": [],
+      "cid": "287099",
+      "name": "ax",
+      "homepage": "",
+      "subject": "",
+      "url": "https://www.drupal.org/project/drupal/issues/16#comment-287099",
+      "edit_url": "https://www.drupal.org/comment/edit/287099",
+      "created": "1008865465",
+      "node": {
+        "uri": "https://www.drupal.org/api-d7/node/16",
+        "id": "16",
+        "resource": "node"
+      },
+      "author": {
+        "uri": "https://www.drupal.org/api-d7/user/8",
+        "id": "8",
+        "resource": "user"
+      },
+      "feeds_item_guid": null,
+      "feeds_item_url": null,
+      "feed_nid": null
+    }
+  ]
+}


### PR DESCRIPTION
As a developer using the drupal.org API, it's common to have to load multiple pages of results. This PR adds a new class that transparently loads new pages as you iterate over a collection.

# Highlights

## Catching errors when decoding

`json_decode()` relies on manually checking error codes via `json_last_error()`. Guzzle used have a function to do this, but it was removed in Guzzle 6. https://github.com/hussainweb/drupal-api-client/commit/28929cf0c467885c0bf8c2a1a0745efca6f11c66 pulls in `symfony/serializer` so we can use it's JSON decoder. I know, it would be nice if it was it's own package, but I think the benefits of familiarity to Drupal developers outweighs the (small) cost of additional code in `vendor`.

## A trait for rel link handling

https://github.com/hussainweb/drupal-api-client/commit/44e6685befe85a0e2afd5dcbdb7070162ea1ed52 lets us share methods between the existing collection class and the new one.

## A new interface for collections

https://github.com/hussainweb/drupal-api-client/commit/e938b8c922dc79b0cc0646207a6718b557d2f46a adds a new interface to the existing collection class. _Technically_ there's a small BC break here because I added return typehinting to the `\Iterator` methods. I personally don't think it's worth rolling a new major release just for this given that code is likely broken if it breaks this contract anyways. If there's disagreement there, I'd be open to removing it or doing a little more refactoring that does break BC more directly.

# Remaining Tasks

- [x] Add a new client method to support using the paging collection https://github.com/hussainweb/drupal-api-client/pull/3/commits/10b59d8dcce129a405e9122aaa36e353d095e90e
- [x] ~~Deprecate `\Hussainweb\DrupalApi\Request\Request::getEntityClass()` and move the responsibility to the request object. As is, it's brittle to extend this since it relies on specific class naming and FQCNs.~~ I decided against this - I think being explicit about class mappings is more robust, but it isn't strictly required for this feature.